### PR TITLE
feat: add realm select

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -102,7 +102,7 @@ export const parameters = {
     }
   },
   chromatic: { viewports: [360] },
-  controls: { disabled: true },
+  controls: { disable: true },
   layout: 'fullscreen',
   viewport: {
     viewports: customViewports

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,8 @@
         "workbox-routing": "^6.5.3",
         "workbox-strategies": "^6.5.3",
         "workbox-streams": "^6.5.3",
-        "yup": "^0.32.11"
+        "yup": "^0.32.11",
+        "zod": "^3.17.10"
       },
       "devDependencies": {
         "@capacitor/cli": "3.6.0",
@@ -34683,6 +34684,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/zod": {
+      "version": "3.17.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.10.tgz",
+      "integrity": "sha512-IHXnQYQuOOOL/XgHhgl8YjNxBHi3xX0mVcHmqsvJgcxKkEczPshoWdxqyFwsARpf41E0v9U95WUROqsHHxt0UQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -61002,6 +61011,11 @@
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
+    },
+    "zod": {
+      "version": "3.17.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.10.tgz",
+      "integrity": "sha512-IHXnQYQuOOOL/XgHhgl8YjNxBHi3xX0mVcHmqsvJgcxKkEczPshoWdxqyFwsARpf41E0v9U95WUROqsHHxt0UQ=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "workbox-routing": "^6.5.3",
     "workbox-strategies": "^6.5.3",
     "workbox-streams": "^6.5.3",
-    "yup": "^0.32.11"
+    "yup": "^0.32.11",
+    "zod": "^3.17.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/PersonDetail/PersonDetail.stories.tsx
+++ b/src/components/PersonDetail/PersonDetail.stories.tsx
@@ -1,5 +1,5 @@
 import { Story, Meta } from '@storybook/react'
-import { screen, userEvent } from '@storybook/testing-library'
+import { userEvent, within } from '@storybook/testing-library'
 
 import {
   getContactHandler,
@@ -51,8 +51,9 @@ TimelineTab.parameters = {
 TimelineTab.args = {
   id: 'timelineId'
 }
-TimelineTab.play = async (): Promise<void> => {
-  await userEvent.click(screen.getByRole('tab', { name: 'Timeline' }))
+TimelineTab.play = async ({ canvasElement }): Promise<void> => {
+  const { getByRole } = within(canvasElement)
+  await userEvent.click(getByRole('tab', { name: 'Timeline' }))
   await userEvent.tab()
   await userEvent.tab()
 }

--- a/src/components/PersonDetail/Timeline/Timeline.stories.tsx
+++ b/src/components/PersonDetail/Timeline/Timeline.stories.tsx
@@ -1,5 +1,5 @@
 import { Story, Meta } from '@storybook/react'
-import { screen, userEvent } from '@storybook/testing-library'
+import { screen, userEvent, within } from '@storybook/testing-library'
 
 import {
   getContactTimelineHandler,
@@ -40,8 +40,9 @@ All.parameters = {
 All.args = {
   id: 'allId'
 }
-All.play = async (): Promise<void> => {
-  await userEvent.click(screen.getByRole('button', { name: 'Filter' }), {})
+All.play = async ({ canvasElement }): Promise<void> => {
+  const canvas = within(canvasElement)
+  await userEvent.click(canvas.getByRole('button', { name: 'Filter' }), {})
   await userEvent.click(screen.getByRole('option', { name: 'All' }))
 }
 

--- a/src/components/RealmSelect/RealmSelect.spec.tsx
+++ b/src/components/RealmSelect/RealmSelect.spec.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { getRealmSelectableHandler } from '../../lib/queries/getRealmSelectable/getRealmSelectable.handlers'
+import { mswServer } from '../../mocks/mswServer'
+import { renderWithProviders } from '../../tests/lib/helpers'
+
+import { RealmSelect } from '.'
+
+describe('RealmSelect', () => {
+  it('calls on change when saved', async () => {
+    mswServer.use(getRealmSelectableHandler())
+    const onChange = jest.fn()
+    renderWithProviders(<RealmSelect onChange={onChange} value={[]} />)
+    fireEvent.mouseDown(await screen.findByRole('button', { name: 'Realm ​' }))
+    const element = await screen.findByText('Tandem Ministries')
+    fireEvent.click(element)
+    fireEvent.click(screen.getByRole('tab', { name: 'Staff Teams' }))
+    fireEvent.click(screen.getByText('Auckland Staff Team'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onChange).toHaveBeenCalledWith(['realmId1', 'realmId13'])
+  })
+
+  it('does not call on change when cancelled', async () => {
+    mswServer.use(getRealmSelectableHandler())
+    const onChange = jest.fn()
+    renderWithProviders(<RealmSelect onChange={onChange} value={[]} />)
+    fireEvent.mouseDown(await screen.findByRole('button', { name: 'Realm ​' }))
+    const element = await screen.findByText('Tandem Ministries')
+    fireEvent.click(element)
+    fireEvent.click(screen.getByRole('tab', { name: 'Staff Teams' }))
+    fireEvent.click(screen.getByText('Auckland Staff Team'))
+    fireEvent.click(screen.getByRole('button', { name: 'close' }))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/RealmSelect/RealmSelect.stories.tsx
+++ b/src/components/RealmSelect/RealmSelect.stories.tsx
@@ -1,0 +1,61 @@
+import { Box } from '@mui/material'
+import { Story, Meta } from '@storybook/react'
+import { useState } from 'react'
+
+import {
+  getRealmSelectableHandler,
+  getRealmSelectableHandlerLoading
+} from '../../lib/queries/getRealmSelectable/getRealmSelectable.handlers'
+
+import { RealmSelectProps } from './RealmSelect'
+
+import { RealmSelect } from '.'
+
+const RealmSelectStory = {
+  title: 'Components/RealmSelect',
+  component: RealmSelect
+}
+
+const Template: Story<RealmSelectProps> = (args) => {
+  const [value, setValue] = useState<string[]>(args.value ?? [])
+
+  return (
+    <Box m={2}>
+      <RealmSelect
+        {...{
+          value,
+          onChange: (value): void => {
+            args.onChange?.(value)
+            setValue(value)
+          }
+        }}
+      />
+    </Box>
+  )
+}
+
+export const Default = Template.bind({})
+Default.parameters = {
+  msw: {
+    handlers: [getRealmSelectableHandler()]
+  }
+}
+
+export const Selected = Template.bind({})
+Selected.parameters = {
+  msw: {
+    handlers: [getRealmSelectableHandler()]
+  }
+}
+Selected.args = {
+  value: ['realmId1', 'realmId2']
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: {
+    handlers: [getRealmSelectableHandlerLoading()]
+  }
+}
+
+export default RealmSelectStory as Meta

--- a/src/components/RealmSelect/RealmSelect.tsx
+++ b/src/components/RealmSelect/RealmSelect.tsx
@@ -1,0 +1,160 @@
+import CloseIcon from '@mui/icons-material/Close'
+import { TabContext, TabList, TabPanel } from '@mui/lab'
+import {
+  AppBar,
+  Button,
+  Dialog,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  Slide,
+  Tab,
+  Toolbar,
+  Typography
+} from '@mui/material'
+import { TransitionProps } from '@mui/material/transitions'
+import { first, xor } from 'lodash'
+import {
+  forwardRef,
+  ReactElement,
+  Ref,
+  SyntheticEvent,
+  useEffect,
+  useState
+} from 'react'
+import { useQuery } from 'react-query'
+
+import { getRealmSelectable } from '../../lib/queries/getRealmSelectable'
+import { GetRealmSelectableParams } from '../../lib/queries/getRealmSelectable/getRealmSelectable'
+
+import { RealmSelectSelect } from './Select'
+import { RealmSelectTreeView } from './TreeView'
+
+const Transition = forwardRef(function Transition(
+  props: TransitionProps & {
+    children: ReactElement
+  },
+  ref: Ref<unknown>
+) {
+  return <Slide direction="up" ref={ref} {...props} />
+})
+
+export interface RealmSelectProps {
+  /** params provided to the Fluro API to filter the displayed realms */
+  params?: GetRealmSelectableParams
+  /** a callback called when the user saves their selection of realms */
+  onChange: (ids: string[]) => void
+  /** an array of realmIds to render as selected */
+  value: string[]
+}
+
+export function RealmSelect({
+  params,
+  onChange,
+  value
+}: RealmSelectProps): ReactElement {
+  const { data, isLoading } = useQuery(
+    params ? ['realmSelectable', params] : 'realmSelectable',
+    getRealmSelectable(params)
+  )
+  const [tab, setTab] = useState('')
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<string[]>(value)
+
+  function handleNodeSelect(_event: SyntheticEvent, nodeIds: string[]): void {
+    setSelected(xor(selected, nodeIds))
+  }
+
+  function handleSave(): void {
+    onChange(selected)
+    setOpen(false)
+  }
+
+  function handleClose(): void {
+    setSelected(value)
+    setOpen(false)
+  }
+
+  useEffect(() => {
+    if (data) setTab(first(data)?.definition ?? '')
+  }, [data])
+
+  const handleOpen = (): void => setOpen(true)
+  const handleTabChange = (_event: SyntheticEvent, newTab: string): void => {
+    setTab(newTab)
+  }
+
+  return isLoading ? (
+    <FormControl fullWidth>
+      <InputLabel id="select-realm-label">Realm</InputLabel>
+      <Select
+        id="select-realm"
+        labelId="select-realm-label"
+        label="Realm"
+        value="loading"
+        disabled
+      >
+        <MenuItem value="loading">
+          <Skeleton width="80%" />
+        </MenuItem>
+      </Select>
+    </FormControl>
+  ) : (
+    <>
+      <RealmSelectSelect onClick={handleOpen} value={value} data={data} />
+      <Dialog
+        fullScreen
+        open={open}
+        onClose={handleClose}
+        TransitionComponent={Transition}
+      >
+        <AppBar sx={{ position: 'relative' }}>
+          <Toolbar>
+            <IconButton
+              edge="start"
+              color="inherit"
+              onClick={handleClose}
+              aria-label="close"
+            >
+              <CloseIcon />
+            </IconButton>
+            <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+              Realms
+            </Typography>
+            <Button autoFocus color="inherit" onClick={handleSave}>
+              Save
+            </Button>
+          </Toolbar>
+        </AppBar>
+        <TabContext value={tab}>
+          <TabList
+            onChange={handleTabChange}
+            variant="scrollable"
+            scrollButtons="auto"
+            sx={{ borderBottom: 1, borderColor: 'divider' }}
+          >
+            {data?.map(({ plural, definition }) => (
+              <Tab label={plural} value={definition} key={definition} />
+            ))}
+          </TabList>
+          {data?.map(({ definition, realms }) => (
+            <TabPanel
+              value={definition}
+              key={definition}
+              sx={{ p: 0, flex: 1, overflow: 'auto' }}
+            >
+              <RealmSelectTreeView
+                realms={realms}
+                selected={selected}
+                onNodeSelect={handleNodeSelect}
+              />
+            </TabPanel>
+          ))}
+        </TabContext>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/RealmSelect/Select/Select.spec.tsx
+++ b/src/components/RealmSelect/Select/Select.spec.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { RealmSelectSelect } from '.'
+
+describe('RealmSelectSelect', () => {
+  it('calls onClick when select opened', () => {
+    const onClick = jest.fn()
+    render(<RealmSelectSelect onClick={onClick} value={[]} data={[]} />)
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Realm ​' }))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('renders realm label for selected', () => {
+    render(
+      <RealmSelectSelect
+        onClick={jest.fn()}
+        value={['realmId1', 'realmId5', 'realmId8']}
+        data={[
+          {
+            realms: [
+              {
+                _id: 'realmId1',
+                title: 'Realm 1',
+                children: [
+                  { _id: 'realmId2', title: 'Realm 2', children: [] },
+                  { _id: 'realmId3', title: 'Realm 3', children: [] }
+                ]
+              },
+              {
+                _id: 'reamlId4',
+                title: 'Realm 4',
+                children: [
+                  { _id: 'realmId5', title: 'Realm 5', children: [] },
+                  { _id: 'realmId6', title: 'Realm 6', children: [] }
+                ]
+              }
+            ]
+          },
+          {
+            realms: [
+              {
+                _id: 'reamlId7',
+                title: 'Realm 7',
+                children: [{ _id: 'realmId8', title: 'Realm 8', children: [] }]
+              }
+            ]
+          }
+        ]}
+      />
+    )
+    expect(screen.getByText('Realm 1, Realm 5, Realm 8')).toBeInTheDocument()
+  })
+})

--- a/src/components/RealmSelect/Select/Select.stories.tsx
+++ b/src/components/RealmSelect/Select/Select.stories.tsx
@@ -1,0 +1,56 @@
+import { Box } from '@mui/material'
+import { Story, Meta } from '@storybook/react'
+
+import { RealmSelectSelectProps } from './Select'
+
+import { RealmSelectSelect } from '.'
+
+const RealmSelectSelectStory = {
+  title: 'Components/RealmSelect/Select',
+  component: RealmSelectSelect,
+  argTypes: { onClick: { action: 'clicked' } }
+}
+
+const Template: Story<RealmSelectSelectProps> = (args) => (
+  <Box m={2}>
+    <RealmSelectSelect {...args} />
+  </Box>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  value: ['realmId1', 'realmId5', 'realmId8'],
+  data: [
+    {
+      realms: [
+        {
+          _id: 'realmId1',
+          title: 'Realm 1',
+          children: [
+            { _id: 'realmId2', title: 'Realm 2', children: [] },
+            { _id: 'realmId3', title: 'Realm 3', children: [] }
+          ]
+        },
+        {
+          _id: 'reamlId4',
+          title: 'Realm 4',
+          children: [
+            { _id: 'realmId5', title: 'Realm 5', children: [] },
+            { _id: 'realmId6', title: 'Realm 6', children: [] }
+          ]
+        }
+      ]
+    },
+    {
+      realms: [
+        {
+          _id: 'reamlId7',
+          title: 'Realm 7',
+          children: [{ _id: 'realmId8', title: 'Realm 8', children: [] }]
+        }
+      ]
+    }
+  ]
+}
+
+export default RealmSelectSelectStory as Meta

--- a/src/components/RealmSelect/Select/Select.tsx
+++ b/src/components/RealmSelect/Select/Select.tsx
@@ -1,0 +1,59 @@
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material'
+import { filter, flatMapDeep, flatMap } from 'lodash'
+import { ReactElement, SyntheticEvent, useMemo } from 'react'
+
+import { Realm } from '../../../lib/queries/getRealmSelectable/getRealmSelectable'
+
+export interface RealmSelectSelectProps {
+  onClick: () => void
+  value: string[]
+  data?: { realms: Realm[] }[]
+}
+
+export function RealmSelectSelect({
+  onClick,
+  value,
+  data
+}: RealmSelectSelectProps): ReactElement {
+  function handleOpen(event: SyntheticEvent): void {
+    event.preventDefault()
+    onClick()
+  }
+
+  const realms = useMemo(() => {
+    if (data === undefined) return
+
+    function getMembers(member: Realm): Realm | (Realm | Realm[])[] {
+      if (!member.children || !member.children.length) {
+        return member
+      }
+      return [member, flatMapDeep(member.children, getMembers)]
+    }
+    const realms = flatMapDeep(
+      flatMap(data, ({ realms }) => realms),
+      getMembers
+    )
+    return filter(realms, ({ _id }) => value.includes(_id))
+  }, [data, value])
+
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="select-realm-label">Realm</InputLabel>
+      <Select
+        id="select-realm"
+        labelId="select-realm-label"
+        label="Realm"
+        onOpen={handleOpen}
+        open={false}
+        value={value}
+        multiple
+      >
+        {realms?.map((realm) => (
+          <MenuItem value={realm._id} key={realm._id}>
+            {realm.title}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/src/components/RealmSelect/Select/index.ts
+++ b/src/components/RealmSelect/Select/index.ts
@@ -1,0 +1,1 @@
+export { RealmSelectSelect } from './Select'

--- a/src/components/RealmSelect/TreeView/TreeView.spec.tsx
+++ b/src/components/RealmSelect/TreeView/TreeView.spec.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { RealmSelectTreeView } from '.'
+
+describe('TreeView', () => {
+  it('calls onNodeSelect', () => {
+    const onNodeSelect = jest.fn()
+    render(
+      <RealmSelectTreeView
+        realms={[
+          {
+            _id: 'realmId1',
+            title: 'Realm 1',
+            children: [
+              { _id: 'realmId2', title: 'Realm 2', children: [] },
+              { _id: 'realmId3', title: 'Realm 3', children: [] }
+            ]
+          },
+          {
+            _id: 'reamlId4',
+            title: 'Realm 4',
+            children: [
+              { _id: 'realmId5', title: 'Realm 5', children: [] },
+              { _id: 'realmId6', title: 'Realm 6', children: [] }
+            ]
+          }
+        ]}
+        selected={[]}
+        onNodeSelect={onNodeSelect}
+      />
+    )
+    fireEvent.click(screen.getByText('Realm 1'))
+    expect(onNodeSelect).toHaveBeenCalled()
+  })
+
+  it('expands all realms with children', () => {
+    render(
+      <RealmSelectTreeView
+        realms={[
+          {
+            _id: 'realmId1',
+            title: 'Realm 1',
+            children: [
+              { _id: 'realmId2', title: 'Realm 2', children: [] },
+              { _id: 'realmId3', title: 'Realm 3', children: [] }
+            ]
+          },
+          {
+            _id: 'reamlId4',
+            title: 'Realm 4',
+            children: [
+              { _id: 'realmId5', title: 'Realm 5', children: [] },
+              { _id: 'realmId6', title: 'Realm 6', children: [] }
+            ]
+          }
+        ]}
+        selected={[]}
+        onNodeSelect={jest.fn()}
+      />
+    )
+    expect(
+      screen.getByRole('treeitem', { name: 'Realm 1 Realm 2 Realm 3' })
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.getByRole('treeitem', { name: 'Realm 4 Realm 5 Realm 6' })
+    ).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('selects based on selected', () => {
+    render(
+      <RealmSelectTreeView
+        realms={[
+          {
+            _id: 'realmId1',
+            title: 'Realm 1',
+            children: [
+              { _id: 'realmId2', title: 'Realm 2', children: [] },
+              { _id: 'realmId3', title: 'Realm 3', children: [] }
+            ]
+          },
+          {
+            _id: 'reamlId4',
+            title: 'Realm 4',
+            children: [
+              { _id: 'realmId5', title: 'Realm 5', children: [] },
+              { _id: 'realmId6', title: 'Realm 6', children: [] }
+            ]
+          }
+        ]}
+        selected={['realmId1', 'realmId3']}
+        onNodeSelect={jest.fn()}
+      />
+    )
+    expect(
+      screen.getByRole('treeitem', { name: 'Realm 1 Realm 2 Realm 3' })
+    ).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('treeitem', { name: 'Realm 3' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(
+      screen.getByRole('treeitem', { name: 'Realm 2' })
+    ).not.toHaveAttribute('aria-selected', 'true')
+  })
+})

--- a/src/components/RealmSelect/TreeView/TreeView.stories.tsx
+++ b/src/components/RealmSelect/TreeView/TreeView.stories.tsx
@@ -1,0 +1,40 @@
+import { Story, Meta } from '@storybook/react'
+
+import { RealmSelectTreeViewProps } from './TreeView'
+
+import { RealmSelectTreeView } from '.'
+
+const RealmSelectSelectStory = {
+  title: 'Components/RealmSelect/TreeView',
+  component: RealmSelectTreeView,
+  argTypes: { onNodeSelect: { action: 'nodeSelected' } }
+}
+
+const Template: Story<RealmSelectTreeViewProps> = (args) => (
+  <RealmSelectTreeView {...args} />
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  selected: ['realmId1', 'realmId5', 'realmId8'],
+  realms: [
+    {
+      _id: 'realmId1',
+      title: 'Realm 1',
+      children: [
+        { _id: 'realmId2', title: 'Realm 2', children: [] },
+        { _id: 'realmId3', title: 'Realm 3', children: [] }
+      ]
+    },
+    {
+      _id: 'reamlId4',
+      title: 'Realm 4',
+      children: [
+        { _id: 'realmId5', title: 'Realm 5', children: [] },
+        { _id: 'realmId6', title: 'Realm 6', children: [] }
+      ]
+    }
+  ]
+}
+
+export default RealmSelectSelectStory as Meta

--- a/src/components/RealmSelect/TreeView/TreeView.tsx
+++ b/src/components/RealmSelect/TreeView/TreeView.tsx
@@ -1,0 +1,77 @@
+import CheckIcon from '@mui/icons-material/Check'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import {
+  MultiSelectTreeViewProps,
+  TreeItem,
+  treeItemClasses,
+  TreeView
+} from '@mui/lab'
+import { flatMapDeep, map } from 'lodash'
+import { ReactElement, useMemo } from 'react'
+
+import { Realm } from '../../../lib/queries/getRealmSelectable/getRealmSelectable'
+
+export interface RealmSelectTreeViewProps {
+  realms: Realm[]
+  selected: string[]
+  onNodeSelect: MultiSelectTreeViewProps['onNodeSelect']
+}
+
+export function RealmSelectTreeView({
+  realms,
+  selected,
+  onNodeSelect
+}: RealmSelectTreeViewProps): ReactElement {
+  const expanded = useMemo(() => {
+    function getMembers(member: Realm): Realm | (Realm | Realm[])[] {
+      if (!member.children || !member.children.length) {
+        return member
+      }
+      return [member, flatMapDeep(member.children, getMembers)]
+    }
+
+    return map(flatMapDeep(realms, getMembers), '_id')
+  }, [realms])
+
+  function renderRealm({ _id, title, children }: Realm): ReactElement {
+    return (
+      <TreeItem
+        key={_id}
+        nodeId={_id}
+        label={title}
+        icon={<CheckIcon />}
+        sx={{
+          [`& .${treeItemClasses.content}`]: {
+            [`& .${treeItemClasses.iconContainer}`]: {
+              opacity: 0
+            },
+            [`&.${treeItemClasses.selected} .${treeItemClasses.iconContainer}`]:
+              {
+                opacity: 1
+              },
+            [`& .${treeItemClasses.label}`]: {
+              lineHeight: 2.8
+            }
+          }
+        }}
+      >
+        {children.map((node) => renderRealm(node))}
+      </TreeItem>
+    )
+  }
+
+  return (
+    <TreeView
+      defaultExpanded={['root']}
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+      selected={selected}
+      expanded={expanded}
+      onNodeSelect={onNodeSelect}
+      multiSelect
+    >
+      {realms.map((realm) => renderRealm(realm))}
+    </TreeView>
+  )
+}

--- a/src/components/RealmSelect/TreeView/index.ts
+++ b/src/components/RealmSelect/TreeView/index.ts
@@ -1,0 +1,1 @@
+export { RealmSelectTreeView } from './TreeView'

--- a/src/components/RealmSelect/index.ts
+++ b/src/components/RealmSelect/index.ts
@@ -1,0 +1,1 @@
+export { RealmSelect } from './RealmSelect'

--- a/src/components/TaskItem/TaskItem.stories.tsx
+++ b/src/components/TaskItem/TaskItem.stories.tsx
@@ -1,5 +1,5 @@
 import { Story, Meta } from '@storybook/react'
-import { screen, userEvent } from '@storybook/testing-library'
+import { screen, userEvent, within } from '@storybook/testing-library'
 
 import {
   updateProcessHandler,
@@ -105,8 +105,9 @@ WithDrawer.parameters = {
     handlers: [updateProcessHandler()]
   }
 }
-WithDrawer.play = async (): Promise<void> => {
-  await userEvent.click(screen.getByRole('button'))
+WithDrawer.play = async ({ canvasElement }): Promise<void> => {
+  const { getByRole } = within(canvasElement)
+  await userEvent.click(getByRole('button'))
 }
 
 export const UpdateSuccessful = Template.bind({})
@@ -120,8 +121,9 @@ UpdateSuccessful.parameters = {
     handlers: [updateProcessHandler()]
   }
 }
-UpdateSuccessful.play = async (): Promise<void> => {
-  await userEvent.click(screen.getByRole('button'))
+UpdateSuccessful.play = async ({ canvasElement }): Promise<void> => {
+  const { getByRole } = within(canvasElement)
+  await userEvent.click(getByRole('button'))
   await userEvent.click(screen.getByRole('button', { name: 'Appointment Set' }))
 }
 
@@ -136,8 +138,9 @@ UpdateFailed.parameters = {
     handlers: [updateProcessHandlerError()]
   }
 }
-UpdateFailed.play = async (): Promise<void> => {
-  await userEvent.click(screen.getByRole('button'))
+UpdateFailed.play = async ({ canvasElement }): Promise<void> => {
+  const { getByRole } = within(canvasElement)
+  await userEvent.click(getByRole('button'))
   await userEvent.click(screen.getByRole('button', { name: 'Appointment Set' }))
 }
 

--- a/src/lib/queries/getRealmSelectable/getRealmSelectable.handlers.ts
+++ b/src/lib/queries/getRealmSelectable/getRealmSelectable.handlers.ts
@@ -1,0 +1,104 @@
+import { rest, RestHandler } from 'msw'
+
+import { GetRealmSelectable } from './getRealmSelectable'
+
+export function getRealmSelectableHandler(): RestHandler {
+  return rest.get('https://api.fluro.io/realm/selectable', (_req, res, ctx) => {
+    return res(
+      ctx.json<GetRealmSelectable>([
+        {
+          plural: 'Realms',
+          definition: 'realm',
+          realms: [
+            {
+              _id: 'realmId1',
+              title: 'Tandem Ministries',
+              children: [
+                {
+                  _id: 'realmId2',
+                  title: 'Athletes in Action',
+                  children: [
+                    {
+                      _id: 'realmId3',
+                      title: 'AIA: AUT: City',
+                      children: []
+                    }
+                  ]
+                },
+                {
+                  _id: 'realmId4',
+                  title: 'FamilyLife',
+                  children: []
+                },
+                {
+                  _id: 'realmId5',
+                  title: 'Member Care',
+                  children: []
+                },
+                {
+                  _id: 'realmId6',
+                  title: 'Student Life',
+                  children: [
+                    {
+                      _id: 'realmId7',
+                      title: 'Other',
+                      children: []
+                    },
+                    {
+                      _id: 'realmId8',
+                      title: 'SL Auckland',
+                      children: [
+                        {
+                          _id: 'realmId9',
+                          title: 'AUT: City',
+                          children: []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  _id: 'realmId10',
+                  title: 'Tandem Photos',
+                  children: []
+                },
+                {
+                  _id: 'realmId11',
+                  title: 'Test Realm',
+                  children: []
+                },
+                {
+                  _id: 'realmId12',
+                  title: 'Work Life',
+                  children: []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          plural: 'Staff Teams',
+          definition: 'staffTeam',
+          realms: [
+            {
+              _id: 'realmId13',
+              title: 'Auckland Staff Team',
+              children: []
+            },
+            {
+              _id: 'realmId14',
+              title: 'Test Staff Team',
+              children: []
+            }
+          ]
+        }
+      ])
+    )
+  })
+}
+
+export function getRealmSelectableHandlerLoading(): RestHandler {
+  return rest.get('https://api.fluro.io/realm/selectable', (_req, res, ctx) => {
+    return res(ctx.delay(1000 * 60 * 60 * 60))
+  })
+}

--- a/src/lib/queries/getRealmSelectable/getRealmSelectable.ts
+++ b/src/lib/queries/getRealmSelectable/getRealmSelectable.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+import { client } from '../../fluro'
+
+interface R {
+  _id: string
+  title: string
+  children: R[]
+}
+
+const realm: z.ZodType<R> = z.lazy(() =>
+  z.object({
+    _id: z.string(),
+    title: z.string(),
+    children: z.array(realm)
+  })
+)
+
+export type Realm = z.infer<typeof realm>
+
+const realmSelectable = z.array(
+  z.object({
+    definition: z.string(),
+    plural: z.string(),
+    realms: z.array(realm)
+  })
+)
+
+export type GetRealmSelectable = z.infer<typeof realmSelectable>
+
+/** Customize the realms retrieved by the API. */
+export interface GetRealmSelectableParams {
+  /** return realms with the provided definition */
+  definition?: string
+  /** filter realms which can receive the parentType */
+  parentType?: string
+  /** filter realms which can receive the type */
+  type?: string
+}
+
+export function getRealmSelectable(
+  params: GetRealmSelectableParams = {}
+): () => Promise<GetRealmSelectable> {
+  return async (): Promise<GetRealmSelectable> => {
+    const response = await client.api.get('/realm/selectable', {
+      params
+    })
+    return realmSelectable.parse(response.data)
+  }
+}

--- a/src/lib/queries/getRealmSelectable/index.ts
+++ b/src/lib/queries/getRealmSelectable/index.ts
@@ -1,0 +1,1 @@
+export { getRealmSelectable } from './getRealmSelectable'

--- a/src/lib/useAuth/index.ts
+++ b/src/lib/useAuth/index.ts
@@ -1,1 +1,1 @@
-export { useAuth, AuthProvider, AuthConsumer } from './useAuth'
+export { useAuth, AuthProvider } from './useAuth'

--- a/src/lib/useAuth/useAuth.tsx
+++ b/src/lib/useAuth/useAuth.tsx
@@ -23,6 +23,8 @@ export interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType>({} as AuthContextType)
 
+AuthContext.displayName = 'AuthConsumer'
+
 export function AuthProvider({
   children,
   initialUser
@@ -121,8 +123,6 @@ export function AuthProvider({
     </AuthContext.Provider>
   )
 }
-
-export const AuthConsumer = AuthContext.Consumer
 
 // Let's only export the `useAuth` hook instead of the context.
 // We only want to use the hook directly and never the context component.


### PR DESCRIPTION
The new realm select component to be used by @storyworks and @edmonday in their forms.

I've also introduced zod. It strongly requires a response from the API in a particular shape otherwise it will halt and throw an error. This gives me some confidence that the object returned from the fluro API will match what we need it to.

QA:
- [ ] select realm and save on default story should show in select
- [ ] selecting some realms in the dialog then clicking close shouldn't change selected realms

This acts somewhat like a TextField. Basic usage:

```tsx
function MyComponent(): ReactElement {
  const [value, setValue] = useState<string[]>([])

  return (
      <RealmSelect
          value={value}
          onChange={setValue}
      />
  )
}
```