### PR TITLE
refactor: get definitions into a hook

### DIFF
--- a/src/components/PersonDetail/Info/Info.tsx
+++ b/src/components/PersonDetail/Info/Info.tsx
@@ -9,17 +9,12 @@ import {
   Skeleton
 } from '@mui/material'
 import { flatMap, map } from 'lodash'
-import { ReactElement, useCallback } from 'react'
+import { ReactElement } from 'react'
 import { useQuery } from 'react-query'
 import { Link } from 'react-router-dom'
 
 import { getContact } from '../../../lib/queries/getContact'
-import {
-  getProcessDefinitions,
-  transformDefinitions,
-  ProcessDefinition,
-  Definition
-} from '../../../lib/queries/getDefinitions'
+import { useDefinitions } from '../../../lib/queries/getDefinitions'
 
 export interface PersonDetailInfoProps {
   id: string
@@ -30,16 +25,8 @@ export function PersonDetailInfo({ id }: PersonDetailInfoProps): ReactElement {
     ['contact', id],
     getContact(id)
   )
-  const { data: processes, isLoading: isProcessesLoading } = useQuery(
-    ['definitions', { type: 'process' }],
-    getProcessDefinitions,
-    {
-      select: useCallback(
-        (data: Definition<ProcessDefinition>) => transformDefinitions(data),
-        []
-      )
-    }
-  )
+  const { data: processes, isLoading: isProcessesLoading } =
+    useDefinitions('process')
 
   return (
     <>

--- a/src/components/PersonList/PersonList.tsx
+++ b/src/components/PersonList/PersonList.tsx
@@ -4,17 +4,12 @@ import TabPanel from '@mui/lab/TabPanel'
 import { Card, CardContent, Skeleton, Typography } from '@mui/material'
 import Tab from '@mui/material/Tab'
 import { Box } from '@mui/system'
-import { ReactElement, useCallback, useMemo, useState } from 'react'
+import { ReactElement, useMemo, useState } from 'react'
 import { useQuery } from 'react-query'
 
 import { getContacts } from '../../lib/queries/getContacts'
 import { GetContacts } from '../../lib/queries/getContacts/getContacts'
-import {
-  Definition,
-  ProcessDefinition,
-  getProcessDefinitions,
-  transformDefinitions
-} from '../../lib/queries/getDefinitions'
+import { useDefinitions } from '../../lib/queries/getDefinitions'
 import { useAuth } from '../../lib/useAuth'
 import { PersonListItem } from '../PersonListItem'
 
@@ -54,16 +49,8 @@ export function PersonList({ search }: PersonListProps): ReactElement {
   const { user } = useAuth()
   const [processType, setProcessType] = useState('all')
 
-  const { data: definitions, isLoading: isDefinitionLoading } = useQuery(
-    ['definitions', { type: 'process' }],
-    getProcessDefinitions,
-    {
-      select: useCallback(
-        (data: Definition<ProcessDefinition>) => transformDefinitions(data),
-        []
-      )
-    }
-  )
+  const { data: definitions, isLoading: isDefinitionLoading } =
+    useDefinitions('process')
 
   const { data: contacts, isLoading: isContactLoading } = useQuery(
     ['contacts', { user: user?.contacts[0] }],

--- a/src/components/PersonListItem/PersonListItem.spec.tsx
+++ b/src/components/PersonListItem/PersonListItem.spec.tsx
@@ -2,10 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 
 import { GetContacts, Process } from '../../lib/queries/getContacts/getContacts'
-import {
-  GetDefinitions,
-  ProcessDefinition
-} from '../../lib/queries/getDefinitions'
+import { UseDefinitionsData } from '../../lib/queries/getDefinitions'
 
 import { PersonListItem } from './PersonListItem'
 
@@ -19,7 +16,7 @@ describe('PersonListItem', () => {
     }
   }
 
-  const definitions: GetDefinitions<ProcessDefinition> = {
+  const definitions: UseDefinitionsData<'process'> = {
     exploreStudy: {
       _id: '0',
       title: 'Explorer',

--- a/src/components/PersonListItem/PersonListItem.tsx
+++ b/src/components/PersonListItem/PersonListItem.tsx
@@ -3,14 +3,11 @@ import { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
 import { GetContacts } from '../../lib/queries/getContacts/getContacts'
-import {
-  GetDefinitions,
-  ProcessDefinition
-} from '../../lib/queries/getDefinitions'
+import { UseDefinitionsData } from '../../lib/queries/getDefinitions'
 
 interface PersonListItemProps {
   contact: GetContacts
-  definitions: GetDefinitions<ProcessDefinition>
+  definitions: UseDefinitionsData<'process'>
 }
 
 export function PersonListItem({

--- a/src/lib/queries/getDefinitions/getDefinitions.handlers.ts
+++ b/src/lib/queries/getDefinitions/getDefinitions.handlers.ts
@@ -1,13 +1,17 @@
 import { rest, RestHandler } from 'msw'
 
-import { Definition, ProcessDefinition, PostDefinition } from './getDefinitions'
+import {
+  DefinitionCollection,
+  ProcessDefinition,
+  PostDefinition
+} from './getDefinitions'
 
 export function getProcessDefinitionsHandler(): RestHandler {
   return rest.post('https://api.fluro.io/defined', (req, res, ctx) => {
     req.body = { types: ['process'] }
     return res(
       ctx.status(200),
-      ctx.json<Definition<ProcessDefinition>[]>([
+      ctx.json<DefinitionCollection<ProcessDefinition>[]>([
         {
           definitionName: 'process',
           definitions: [
@@ -97,7 +101,7 @@ export function getPostDefinitionsHandler(): RestHandler {
     req.body = { types: ['post'] }
     return res(
       ctx.status(200),
-      ctx.json<Definition<PostDefinition>[]>([
+      ctx.json<DefinitionCollection<PostDefinition>[]>([
         {
           definitionName: 'post',
           definitions: [

--- a/src/lib/queries/getDefinitions/getDefinitions.hook.ts
+++ b/src/lib/queries/getDefinitions/getDefinitions.hook.ts
@@ -1,0 +1,33 @@
+import { reduce } from 'lodash'
+import { useQuery } from 'react-query'
+
+import {
+  getDefinitions,
+  ProcessTypeName,
+  ProcessObjectType
+} from './getDefinitions'
+
+type UseDefinitionsResult<T> = ReturnType<
+  typeof useQuery<
+    ProcessObjectType<T>[],
+    unknown,
+    { [definitionName: string]: ProcessObjectType<T> },
+    { type: T }[]
+  >
+>
+
+export function useDefinitions<T extends ProcessTypeName>(
+  type: T
+): UseDefinitionsResult<T> {
+  return useQuery(['definitions', { type }], getDefinitions(type), {
+    select: (data) =>
+      reduce(
+        data,
+        (result, definition) => {
+          result[definition.definitionName] = definition
+          return result
+        },
+        {} as { [definitionName: string]: typeof data[number] }
+      )
+  })
+}

--- a/src/lib/queries/getDefinitions/getDefinitions.hook.ts
+++ b/src/lib/queries/getDefinitions/getDefinitions.hook.ts
@@ -3,20 +3,24 @@ import { useQuery } from 'react-query'
 
 import {
   getDefinitions,
-  ProcessTypeName,
-  ProcessObjectType
+  DefinitionTypeName,
+  DefinitionObjectType
 } from './getDefinitions'
 
-type UseDefinitionsResult<T> = ReturnType<
+export type UseDefinitionsData<T> = {
+  [definitionName: string]: DefinitionObjectType<T>
+}
+
+export type UseDefinitionsResult<T> = ReturnType<
   typeof useQuery<
-    ProcessObjectType<T>[],
+    DefinitionObjectType<T>[],
     unknown,
-    { [definitionName: string]: ProcessObjectType<T> },
+    UseDefinitionsData<T>,
     { type: T }[]
   >
 >
 
-export function useDefinitions<T extends ProcessTypeName>(
+export function useDefinitions<T extends DefinitionTypeName>(
   type: T
 ): UseDefinitionsResult<T> {
   return useQuery(['definitions', { type }], getDefinitions(type), {

--- a/src/lib/queries/getDefinitions/getDefinitions.ts
+++ b/src/lib/queries/getDefinitions/getDefinitions.ts
@@ -34,20 +34,20 @@ export interface PostDefinition extends Definition {
   }[]
 }
 
-export type ProcessTypeName = 'process' | 'post'
+export type DefinitionTypeName = 'process' | 'post'
 
-export type ProcessObjectType<T> = T extends 'process'
+export type DefinitionObjectType<T> = T extends 'process'
   ? ProcessDefinition
   : T extends 'post'
   ? PostDefinition
   : never
 
-export function getDefinitions<T extends ProcessTypeName>(
+export function getDefinitions<T extends DefinitionTypeName>(
   type: T
-): () => Promise<ProcessObjectType<T>[]> {
-  return async (): Promise<ProcessObjectType<T>[]> => {
+): () => Promise<DefinitionObjectType<T>[]> {
+  return async (): Promise<DefinitionObjectType<T>[]> => {
     const data = await client.types.retrieve<
-      DefinitionCollection<ProcessObjectType<T>>
+      DefinitionCollection<DefinitionObjectType<T>>
     >([type])
     return data[0].definitions
   }

--- a/src/lib/queries/getDefinitions/index.ts
+++ b/src/lib/queries/getDefinitions/index.ts
@@ -1,11 +1,8 @@
-export {
-  getPostDefinitions,
-  getProcessDefinitions,
-  transformDefinitions
-} from './getDefinitions'
+export { useDefinitions } from './getDefinitions.hook'
+export { getDefinitions } from './getDefinitions'
 export type {
-  Definition,
-  GetDefinitions,
+  ProcessDefinition,
   PostDefinition,
-  ProcessDefinition
+  ProcessTypeName,
+  ProcessObjectType
 } from './getDefinitions'

--- a/src/lib/queries/getDefinitions/index.ts
+++ b/src/lib/queries/getDefinitions/index.ts
@@ -1,8 +1,12 @@
 export { useDefinitions } from './getDefinitions.hook'
+export type {
+  UseDefinitionsData,
+  UseDefinitionsResult
+} from './getDefinitions.hook'
 export { getDefinitions } from './getDefinitions'
 export type {
   ProcessDefinition,
   PostDefinition,
-  ProcessTypeName,
-  ProcessObjectType
+  DefinitionTypeName,
+  DefinitionObjectType
 } from './getDefinitions'


### PR DESCRIPTION
This moves the previous useQuery and transform logic into a hook called useDefinitions where you just provide an argument of either process or post and it returns you a strongly typed data object.

This is primarily designed to simplify types.